### PR TITLE
Patch

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,10 +1,16 @@
 local_install_openmpp <- function() {
-  latest <- gh::gh("https://api.github.com/repos/openmpp/main/releases/latest")
+  all_releases <- gh::gh("https://api.github.com/repos/openmpp/main/releases")
+  all_releases <- all_releases[order(sapply(all_releases, \(x) x$published_at), decreasing = TRUE)]
+
   info <- Sys.info()
   os <- info['sysname']
   type <- info['machine']
 
-  url <- find_latest_binary(latest$assets, os, type)
+  url <- search_releases(all_releases, os, type)
+
+  if (is.null(url)) {
+    rlang::abort('No compatible binary found.')
+  }
 
   file <- basename(url)
 
@@ -46,6 +52,21 @@ find_latest_binary <- function(assets, os, type) {
   }
 
   url
+}
+
+search_releases <- function(releases, os, type) {
+  binary <- NULL
+  for (release in releases) {
+    tryCatch({
+      binary <- find_latest_binary(release$assets, os, type)
+    },
+    error = function(e) {
+    })
+    if (!is.null(binary)) {
+      break
+    }
+  }
+  binary
 }
 
 oms_path <- local_install_openmpp()

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -9,7 +9,7 @@ local_install_openmpp <- function() {
   url <- search_releases(all_releases, os, type)
 
   if (is.null(url)) {
-    rlang::abort('No compatible binary found.')
+    rlang::abort('No compatible openmpp binary found.')
   }
 
   file <- basename(url)


### PR DESCRIPTION
Patch for #18. 

Test setup will now iterate through releases (in decreasing date order) until a compatible release (for OS and type) is found. This means that testing may not be using the latest `openmpp` version (if a compatible release is not available), but at least the testing will still run with the most recent compatible version. 

If none are found (should not really happen unless http is down), then fails with a helpful error.